### PR TITLE
Add tests to verify OpenAPI presence

### DIFF
--- a/cmd/kube-apiserver/app/testing/server_test.go
+++ b/cmd/kube-apiserver/app/testing/server_test.go
@@ -395,7 +395,6 @@ func TestOpenAPIPresence(t *testing.T) {
 	defer tearDown()
 
 	kubeclient, err := kubernetes.NewForConfig(config)
-
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -403,7 +402,6 @@ func TestOpenAPIPresence(t *testing.T) {
 	result := kubeclient.RESTClient().Get().AbsPath("/swagger.json").Do()
 	status := 0
 	result.StatusCode(&status)
-
 	if status != 200 {
 		t.Fatalf("GET /swagger.json failed: expected status=%d, got=%d", 200, status)
 	}
@@ -418,7 +416,6 @@ func TestOpenAPIPresence(t *testing.T) {
 	}
 
 	var doc openAPISchema
-
 	err = json.Unmarshal(raw, &doc)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
@@ -443,10 +440,10 @@ func TestOpenAPIPresence(t *testing.T) {
 	}
 
 	if !matchedExtension {
-		t.Fatalf("missing path: %q", extensionsPrefix)
+		t.Errorf("missing path: %q", extensionsPrefix)
 	}
 
 	if !matchedRegistration {
-		t.Fatalf("missing path: %q", registrationPrefix)
+		t.Errorf("missing path: %q", registrationPrefix)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The unit test validates that the path '/apis/apiextensions.k8s.io' is
both enabled and discovered in the test server delegation chain.

**Which issue this PR fixes** 

Unit test case for #50011.

**Special notes for your reviewer**:

This is dependent on PR #50864.

**Release note**:

```release-note
```